### PR TITLE
Bump requests to 2.33.0 to fix Dependabot alerts

### DIFF
--- a/requirements-catalog.txt
+++ b/requirements-catalog.txt
@@ -1,3 +1,3 @@
 gpxpy==1.5.0
-requests==2.31.0
+requests==2.33.0
 jsonpickle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 gpxpy==1.5.0
-requests==2.31.0
+requests==2.33.0


### PR DESCRIPTION
## Summary
- Bumps `requests` from 2.31.0 to 2.33.0 in `requirements.txt` and `requirements-catalog.txt`
- Resolves 6 open medium-severity Dependabot alerts:
  - CVE-2024-35195 (Session TLS verification bypass persists after `verify=False`)
  - CVE-2024-47081 (`.netrc` credential leak via crafted URLs)
  - CVE-2026-25645 (insecure temp file reuse in `extract_zipped_paths()`)

## Test plan
- [ ] Trigger the "Refresh Boeien files" workflow against this branch to confirm the scripts still run correctly with `requests` 2.33.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Updates**
  * Updated the NL-Boeien waypoint data, including revised waypoint coordinates, symbol/model text adjustments, and removed/updated specific waypoint entries.
  * Refreshed NL-Boeien chart metadata (checksum and update timestamps) so the catalog reflects the latest version.
* **Chores**
  * Updated the `requests` dependency to version `2.33.0` in the project’s dependency lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->